### PR TITLE
Use entire chat history for model prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # linguaspark
+
+## Manual Testing
+
+1. Install dependencies and run the app:
+
+   ```bash
+   pip install -r requirements.txt
+   streamlit run lingua.py
+   ```
+
+2. Start a chat and send at least two messages.
+3. The assistant's reply should reference earlier messages, showing that the
+   full conversation history is sent to the model.

--- a/lingua.py
+++ b/lingua.py
@@ -8,6 +8,20 @@ from datetime import date
 import time
 import re
 
+# --- Helper ---
+def _trim_history(history, max_chars=12000):
+    """Return the most recent messages that fit within max_chars."""
+    total = 0
+    trimmed = []
+    for msg in reversed(history):
+        content = msg.get("content", "")
+        msg_len = len(content)
+        if total + msg_len > max_chars:
+            break
+        trimmed.append(msg)
+        total += msg_len
+    return list(reversed(trimmed))
+
 # --- CONFIG ---
 st.set_page_config(
     page_title="Falowen – Your AI Conversation Partner",
@@ -421,10 +435,8 @@ if st.session_state["step"] == 5:
                 ai_system_prompt += f"\nNext topic: {next_topic}"
 
             # --- OpenAI Chat Completion ---
-            conversation = [
-                {"role": "system", "content": ai_system_prompt},
-                st.session_state["messages"][-1]
-            ]
+            trimmed = _trim_history(st.session_state["messages"])
+            conversation = [{"role": "system", "content": ai_system_prompt}] + trimmed
             with st.spinner("🧑‍🏫 Herr Felix is typing..."):
                 try:
                     client = OpenAI(api_key=st.secrets["general"]["OPENAI_API_KEY"])


### PR DESCRIPTION
## Summary
- keep recent chat history within a size limit
- send the trimmed history to OpenAI with the system prompt
- document manual steps to check conversation memory

## Testing
- `python -m py_compile lingua.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68511dc761fc83218d0b21505e5ed3f1