### PR TITLE
Use env/secrets for teacher password

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # linguaspark
+
+Falowen is a Streamlit app that helps students practice German conversation with AI.
+
+## Setup
+
+The teacher dashboard is protected by a password. Supply this value either via the
+`TEACHER_PASSWORD` environment variable or by defining `teacher_password` in your
+Streamlit `secrets.toml` file.

--- a/lingua.py
+++ b/lingua.py
@@ -32,7 +32,10 @@ st.markdown(
 CODES_FILE = "student_codes.csv"
 DAILY_LIMIT = 25
 MAX_TURNS = 10
-TEACHER_PASSWORD = "Felix029"
+# Teacher password can be provided via environment variable or Streamlit secrets
+TEACHER_PASSWORD = os.environ.get("TEACHER_PASSWORD")
+if not TEACHER_PASSWORD:
+    TEACHER_PASSWORD = st.secrets.get("teacher_password", "")
 
 A2_TEIL2 = [
     "Was machen Sie mit Ihrem Geld?",


### PR DESCRIPTION
## Summary
- read teacher password from `TEACHER_PASSWORD` env var or Streamlit secrets
- document password configuration in README

## Testing
- `python -m py_compile lingua.py`

------
https://chatgpt.com/codex/tasks/task_e_68511fe939d4832197813215c512f793