### PR TITLE
Send full chat history

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,5 @@
    ```
 
 2. Start a chat and send at least two messages.
-3. The assistant's reply should reference earlier messages, showing that the
-   full conversation history is sent to the model.
+3. The assistant's reply should reference earlier messages. The app sends the
+   **full conversation history** with every request.

--- a/lingua.py
+++ b/lingua.py
@@ -536,10 +536,10 @@ if st.session_state["step"] == 5:
                         "Answer in B1 German, correct if needed, give a tip in English, then ask the next question."
                     )
 
-            conversation = [
-                {"role": "system", "content": ai_system_prompt},
-                st.session_state["messages"][-1]
-            ]
+            conversation = (
+                [{"role": "system", "content": ai_system_prompt}]
+                + st.session_state["messages"]
+            )
             with st.spinner("🧑‍🏫 Herr Felix is typing..."):
                 try:
                     client = OpenAI(api_key=st.secrets["general"]["OPENAI_API_KEY"])


### PR DESCRIPTION
## Summary
- include all previous chat messages when sending a request to OpenAI
- clarify in the README that the entire conversation history is sent

## Testing
- `python -m py_compile lingua.py`

------
https://chatgpt.com/codex/tasks/task_e_68512816af188321b07d8881a5e8a767