### PR TITLE
Remove unused custom_level_prompted state

### DIFF
--- a/lingua.py
+++ b/lingua.py
@@ -583,7 +583,6 @@ if st.session_state["step"] == 5:
                 "messages": [],
                 "turn_count": 0,
                 "custom_chat_level": None,
-                "custom_level_prompted": False,
             })
     with col2:
         if session_ended and st.button("Next ➡️ (Summary)", key="stage5_summary"):


### PR DESCRIPTION
## Summary
- delete unused `custom_level_prompted` session key

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851281e0aa48321b8b213be7c1f475f